### PR TITLE
docs: correct formatting of invalid usage examples

### DIFF
--- a/content/v0.0.1/index.md
+++ b/content/v0.0.1/index.md
@@ -168,7 +168,7 @@ discriminant.
 ]
 ```
 
-*** DON'T ***
+***DON'T***
 
 ```
 [
@@ -222,7 +222,7 @@ discriminant.
 ]
 ```
 
-*** DON'T ***
+***DON'T***
 
 ```
 [
@@ -260,7 +260,7 @@ discriminant.
 ]
 ```
 
-*** DON'T ***
+***DON'T***
 
 ```
 [


### PR DESCRIPTION
Fixes markdown formatting of the "DON'T" examples

Before:

<img width="1176" alt="image" src="https://user-images.githubusercontent.com/7580355/171338651-ed50081a-604b-41bd-a857-da10f7776eb1.png">

After:

<img width="1076" alt="image" src="https://user-images.githubusercontent.com/7580355/171339140-91dae4ec-19e4-49c8-9719-85fb8927a4a7.png">

